### PR TITLE
Rows returning a Stream.resource instead of array.

### DIFF
--- a/lib/req_bigquery.ex
+++ b/lib/req_bigquery.ex
@@ -218,6 +218,7 @@ defmodule ReqBigQuery do
         # last iteration didn't have pageToken
         nil
     end)
+    |> Stream.flat_map(& &1)
   end
 
   defp page_request(options, project_id, job_id, page_token) do

--- a/lib/req_bigquery.ex
+++ b/lib/req_bigquery.ex
@@ -33,7 +33,7 @@ defmodule ReqBigQuery do
 
     * `:max_results` - Optional. Number of rows to be returned by BigQuery in each request (paging).
       The rows Stream can make multiple requests if `num_rows` returned is grather than `:max_results`.
-      default: 10000.
+      Defaults to 10000.
 
   If you want to set any of these options when attaching the plugin, pass them as the second argument.
 
@@ -62,7 +62,7 @@ defmodule ReqBigQuery do
         num_rows: 10,
         rows: %Stream{}
       }
-      iex> res.rows |> Enum.to_list()
+      iex> Enum.to_list(res.rows)
       [
           ["The_Beatles", 13758950],
           ["Queen_(band)", 12019563],
@@ -98,7 +98,7 @@ defmodule ReqBigQuery do
         num_rows: 7,
         rows: %Stream{}
       }
-      iex> res.rows |> Enum.to_list()
+      iex> Enum.to_list(res.rows)
       [[2017, 2895889], [2016, 1173359], [2018, 1133770], [2020, 906538], [2015, 860899], [2019, 790747], [2021, 481600]]
 
   """
@@ -122,7 +122,8 @@ defmodule ReqBigQuery do
       uri = URI.parse("#{base_url}/projects/#{options.project_id}/queries")
 
       json =
-        build_request_body(query, options[:default_dataset_id])
+        query
+        |> build_request_body(options[:default_dataset_id])
         |> Map.put(:maxResults, options.max_results)
 
       %{request | url: uri}

--- a/lib/req_bigquery.ex
+++ b/lib/req_bigquery.ex
@@ -181,7 +181,7 @@ defmodule ReqBigQuery do
     %Result{
       job_id: job_id,
       num_rows: String.to_integer(num_rows),
-      rows: rows_stream(initial_response, request_options) |> decode_rows(fields),
+      rows: initial_response |> rows_stream(request_options) |> decode_rows(fields),
       columns: decode_columns(fields)
     }
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -74,7 +74,7 @@ defmodule IntegrationTest do
 
     result = response.body
 
-    assert is_struct(result.rows, Stream)
+    assert %Stream{} = result.rows
 
     assert result.rows |> Enum.take(4) == [
              [~U[2015-05-01 01:00:00.000000Z], "Butter_08", 1],
@@ -148,9 +148,8 @@ defmodule IntegrationTest do
 
     assert result.columns == ["year", "views"]
     assert result.num_rows == 7
-    rows = result.rows |> Enum.to_list()
 
-    assert rows == [
+    assert Enum.to_list(result.rows) == [
              [2017, 2_895_889],
              [2016, 1_173_359],
              [2018, 1_133_770],
@@ -214,9 +213,7 @@ defmodule IntegrationTest do
 
     value = Decimal.new("1.1")
 
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
-             [value]
-           ]
+    assert run_decoding_query(req, value) == [[value]]
 
     decimal = Decimal.new("1.10")
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -261,7 +261,7 @@ defmodule IntegrationTest do
 
     value = NaiveDateTime.utc_now()
 
-    assert run_decoding_query(req, value) |> Enum.to_list() == [[value]]
+    assert run_decoding_query(req, value) == [[value]]
 
     value = DateTime.utc_now()
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -294,6 +294,7 @@ defmodule IntegrationTest do
   end
 
   defp run_custom_query(req, query) do
-    Req.post!(req, bigquery: query).body.rows |> Enum.to_list()
+    result = Req.post!(req, bigquery: query).body
+    Enum.to_list(result)
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -49,7 +49,7 @@ defmodule IntegrationTest do
            ]
   end
 
-  test "If max_results (paging) < response num_rows, the stream requests new pages and brings all the rows",
+  test "requests new pages and brings all the rows when max_results (paging) < response num_rows",
        %{test: goth} do
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -295,6 +295,6 @@ defmodule IntegrationTest do
 
   defp run_custom_query(req, query) do
     result = Req.post!(req, bigquery: query).body
-    Enum.to_list(result)
+    Enum.to_list(result.rows)
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -249,7 +249,7 @@ defmodule IntegrationTest do
 
     value = String.to_float("3.402823466E+38")
 
-    assert run_decoding_query(req, value) |> Enum.to_list() == [[value]]
+    assert run_decoding_query(req, value) == [[value]]
 
     value = Date.utc_today()
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -257,7 +257,7 @@ defmodule IntegrationTest do
 
     value = Time.utc_now()
 
-    assert run_decoding_query(req, value) |> Enum.to_list() == [[value]]
+    assert run_decoding_query(req, value) == [[value]]
 
     value = NaiveDateTime.utc_now()
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -253,7 +253,7 @@ defmodule IntegrationTest do
 
     value = Date.utc_today()
 
-    assert run_decoding_query(req, value) |> Enum.to_list() == [[value]]
+    assert run_decoding_query(req, value) == [[value]]
 
     value = Time.utc_now()
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -3,12 +3,12 @@ defmodule IntegrationTest do
   @moduletag :integration
 
   test "returns the Google BigQuery's response", %{test: goth} do
-    project_id = System.fetch_env!("PROJECT_ID")
-
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
       |> File.read!()
       |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
 
     source = {:service_account, credentials, []}
     start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
@@ -33,8 +33,9 @@ defmodule IntegrationTest do
 
     assert result.columns == ["title", "views"]
     assert result.num_rows == 10
+    rows = result.rows |> Enum.to_list()
 
-    assert result.rows == [
+    assert rows == [
              ["The_Beatles", 13_758_950],
              ["Queen_(band)", 12_019_563],
              ["Pink_Floyd", 9_522_503],
@@ -48,13 +49,48 @@ defmodule IntegrationTest do
            ]
   end
 
-  test "returns the Google BigQuery's response without rows", %{test: goth} do
-    project_id = System.fetch_env!("PROJECT_ID")
-
+  test "If max_results (paging) < response num_rows, the stream requests new pages and brings all the rows",
+       %{test: goth} do
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
       |> File.read!()
       |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
+    source = {:service_account, credentials, []}
+    start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
+
+    query = """
+    SELECT *
+      FROM `bigquery-public-data.wikipedia.table_bands`
+      ORDER BY datehour asc
+      LIMIT 10
+    """
+
+    response =
+      Req.new()
+      |> ReqBigQuery.attach(project_id: project_id, goth: goth, max_results: 2)
+      |> Req.post!(bigquery: query)
+
+    result = response.body
+
+    assert is_struct(result.rows, Stream)
+
+    assert result.rows |> Enum.take(4) == [
+             [~U[2015-05-01 01:00:00.000000Z], "Butter_08", 1],
+             [~U[2015-05-01 01:00:00.000000Z], "The_Pipkins", 1],
+             [~U[2015-05-01 01:00:00.000000Z], "Project_One", 1],
+             [~U[2015-05-01 01:00:00.000000Z], "Gatibu", 1]
+           ]
+  end
+
+  test "returns the Google BigQuery's response without rows", %{test: goth} do
+    credentials =
+      System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
+      |> File.read!()
+      |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
 
     source = {:service_account, credentials, []}
     start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
@@ -82,12 +118,12 @@ defmodule IntegrationTest do
   end
 
   test "returns the Google BigQuery's response with parameterized query", %{test: goth} do
-    project_id = System.fetch_env!("PROJECT_ID")
-
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
       |> File.read!()
       |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
 
     source = {:service_account, credentials, []}
     start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
@@ -112,8 +148,9 @@ defmodule IntegrationTest do
 
     assert result.columns == ["year", "views"]
     assert result.num_rows == 7
+    rows = result.rows |> Enum.to_list()
 
-    assert result.rows == [
+    assert rows == [
              [2017, 2_895_889],
              [2016, 1_173_359],
              [2018, 1_133_770],
@@ -127,12 +164,12 @@ defmodule IntegrationTest do
   test "returns the Google BigQuery's response with more than one parameterized query", %{
     test: goth
   } do
-    project_id = System.fetch_env!("PROJECT_ID")
-
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
       |> File.read!()
       |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
 
     source = {:service_account, credentials, []}
     start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
@@ -156,18 +193,19 @@ defmodule IntegrationTest do
     assert result.columns == ["en_description"]
     assert result.num_rows == 1
 
-    assert result.rows == [["fruit of the apple tree"]]
+    rows = result.rows |> Enum.to_list()
+    assert rows == [["fruit of the apple tree"]]
   end
 
   test "encodes and decodes types received from Google BigQuery's response", %{
     test: goth
   } do
-    project_id = System.fetch_env!("PROJECT_ID")
-
     credentials =
       System.get_env("GOOGLE_APPLICATION_CREDENTIALS", "credentials.json")
       |> File.read!()
       |> Jason.decode!()
+
+    project_id = System.get_env("PROJECT_ID", credentials["project_id"])
 
     source = {:service_account, credentials, []}
     start_supervised!({Goth, name: goth, source: source, http_client: &Req.request/1})
@@ -175,63 +213,110 @@ defmodule IntegrationTest do
     req = Req.new() |> ReqBigQuery.attach(project_id: project_id, goth: goth)
 
     value = Decimal.new("1.1")
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     decimal = Decimal.new("1.10")
-    assert Req.post!(req, bigquery: {"SELECT ?", [decimal]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [decimal]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = Decimal.new("-1.1")
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = "req"
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = 1
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = 1.1
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = -1.1
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = true
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = String.to_float("1.175494351E-38")
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = String.to_float("3.402823466E+38")
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = Date.utc_today()
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = Time.utc_now()
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = NaiveDateTime.utc_now()
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = DateTime.utc_now()
-    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: {"SELECT ?", [value]}).body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = %{"id" => 1}
-    assert Req.post!(req, bigquery: "SELECT STRUCT(1 AS id)").body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: "SELECT STRUCT(1 AS id)").body.rows |> Enum.to_list() == [
+             [value]
+           ]
 
     value = %{"ids" => [10, 20]}
-    assert Req.post!(req, bigquery: "SELECT STRUCT([10,20] AS ids)").body.rows == [[value]]
+
+    assert Req.post!(req, bigquery: "SELECT STRUCT([10,20] AS ids)").body.rows |> Enum.to_list() ==
+             [[value]]
 
     assert_raise RuntimeError, "float value \"-Infinity\" is not supported", fn ->
-      Req.post!(req, bigquery: "SELECT CAST('-inf' AS FLOAT64)")
+      Req.post!(req, bigquery: "SELECT CAST('-inf' AS FLOAT64)").body.rows |> Stream.run()
     end
 
     assert_raise RuntimeError, "float value \"Infinity\" is not supported", fn ->
-      Req.post!(req, bigquery: "SELECT CAST('+inf' AS FLOAT64)")
+      Req.post!(req, bigquery: "SELECT CAST('+inf' AS FLOAT64)").body.rows |> Stream.run()
     end
 
     assert_raise RuntimeError, "float value \"NaN\" is not supported", fn ->
-      Req.post!(req, bigquery: "SELECT CAST('NaN' AS FLOAT64)")
+      Req.post!(req, bigquery: "SELECT CAST('NaN' AS FLOAT64)").body.rows |> Stream.run()
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -265,7 +265,7 @@ defmodule IntegrationTest do
 
     value = DateTime.utc_now()
 
-    assert run_decoding_query(req, value) |> Enum.to_list() == [[value]]
+    assert run_decoding_query(req, value) == [[value]]
 
     value = %{"id" => 1}
 

--- a/test/req_bigquery_test.exs
+++ b/test/req_bigquery_test.exs
@@ -17,7 +17,8 @@ defmodule ReqBigQueryTest do
     fake_bigquery = fn request ->
       assert Jason.decode!(request.body) == %{
                "defaultDataset" => %{"datasetId" => "my_awesome_dataset"},
-               "query" => "select * from iris"
+               "query" => "select * from iris",
+               "maxResults" => 10000
              }
 
       assert URI.to_string(request.url) ==
@@ -58,12 +59,14 @@ defmodule ReqBigQueryTest do
 
     assert response.status == 200
 
-    assert response.body == %ReqBigQuery.Result{
+    assert %ReqBigQuery.Result{
              columns: ["id", "name"],
              job_id: "job_KuHEcplA2ICv8pSqb0QeOVNNpDaX",
              num_rows: 2,
-             rows: [[1, "Ale"], [2, "Wojtek"]]
-           }
+             rows: %Stream{}
+           } = response.body
+
+    assert Enum.to_list(response.body.rows) == [[1, "Ale"], [2, "Wojtek"]]
   end
 
   test "executes a parameterized query", ctx do
@@ -90,7 +93,8 @@ defmodule ReqBigQueryTest do
                    "parameterValue" => %{"value" => 10.4}
                  }
                ],
-               "useLegacySql" => false
+               "useLegacySql" => false,
+               "maxResults" => 10000
              }
 
       assert URI.to_string(request.url) ==
@@ -131,12 +135,14 @@ defmodule ReqBigQueryTest do
 
     assert response.status == 200
 
-    assert response.body == %ReqBigQuery.Result{
+    assert %ReqBigQuery.Result{
              columns: ["id", "name"],
              job_id: "job_KuHEcplA2ICv8pSqb0QeOVNNpDaX",
              num_rows: 2,
-             rows: [[1, "Ale"], [2, "Wojtek"]]
-           }
+             rows: %Stream{}
+           } = response.body
+
+    assert Enum.to_list(response.body.rows) == [[1, "Ale"], [2, "Wojtek"]]
   end
 
   defp goth_credentials do


### PR DESCRIPTION
Hi team!

**Rows returns a stream that can call BigQuery API again for new pages.**
Also added the `max_results` option (page size), used for testing purposes (checking if it was calling many times)

It could be totally async (first call just launch the job, and then call each page when traversing the Stream, but there where 2 problems with that approach:

- We needed a synchronous call to get the `num_rows` (One option was to call it with max_results : 0, and then increase the `max_results` in subsequent requests). 
- First page would be called many times as kino shows the results.

Instead, the Stream comes with the first page "in memory" and only calls BigQuery when traversing the stream after the `max_results`.

Hope you like it!