### PR TITLE
Always call BigQuery API with useLegacySql set to false

### DIFF
--- a/lib/req_bigquery.ex
+++ b/lib/req_bigquery.ex
@@ -127,6 +127,7 @@ defmodule ReqBigQuery do
         query
         |> build_request_body(options[:default_dataset_id])
         |> Map.put(:maxResults, options[:max_results])
+        |> Map.put(:useLegacySql, false)
 
       %{request | url: uri}
       |> Request.merge_options(auth: {:bearer, token}, json: json)
@@ -157,7 +158,7 @@ defmodule ReqBigQuery do
   end
 
   defp build_request_body(query, dataset) when dataset in ["", nil] do
-    %{query: query, useLegacySql: false}
+    %{query: query}
   end
 
   defp build_request_body(query, dataset) when is_binary(query) do

--- a/test/req_bigquery_test.exs
+++ b/test/req_bigquery_test.exs
@@ -18,7 +18,8 @@ defmodule ReqBigQueryTest do
       assert Jason.decode!(request.body) == %{
                "defaultDataset" => %{"datasetId" => "my_awesome_dataset"},
                "query" => "select * from iris",
-               "maxResults" => 10000
+               "maxResults" => 10000,
+               "useLegacySql" => false
              }
 
       assert URI.to_string(request.url) ==


### PR DESCRIPTION
Fix https://github.com/livebook-dev/req_bigquery/issues/25
Ensure useLegacySql=false is included in all API requests to BigQuery, regardless of default_dataset_id being set or not.