### PR TITLE
Add dry run support

### DIFF
--- a/lib/req_bigquery/result.ex
+++ b/lib/req_bigquery/result.ex
@@ -8,17 +8,19 @@ defmodule ReqBigQuery.Result do
     * `rows` - The result set. A list of lists, each inner list corresponding to a
       row, each element in the inner list corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
-    * `job_id` - The ID of the Google BigQuery's executed job.
+    * `total_bytes_processed` - The total number of bytes processed for the query;
+    * `job_id` - The ID of the Google BigQuery's executed job. Returns nil for dry runs.
   """
 
   @type t :: %__MODULE__{
           columns: [String.t()],
           rows: [[term()] | binary()],
           num_rows: non_neg_integer(),
-          job_id: binary()
+          total_bytes_processed: non_neg_integer(),
+          job_id: binary() | nil
         }
 
-  defstruct [:job_id, num_rows: 0, rows: [], columns: []]
+  defstruct [:job_id, :total_bytes_processed, num_rows: 0, rows: [], columns: []]
 end
 
 if Code.ensure_loaded?(Table.Reader) do


### PR DESCRIPTION
## Context

It is [good practice](https://cloud.google.com/bigquery/docs/best-practices-costs#estimate-query-costs) for BigQuery queries to be  run in dry run mode before actually running the query when [on-demand pricing](https://cloud.google.com/bigquery/pricing#on_demand_pricing) model is used. That way, the total amount of bytes that a query would process can be known beforehand, enabling users to make fine adjustments to it in case the resulting costs are too high.

Currently, req_bigquery offers no support to run BigQuery queries in dry run mode, nor does it return the associated total bytes that the query processed.

## Proposed solution

- Add `dry_run` option to run queries in dry run mode;
- Add resulting `total_bytes_processed` to `ReqBigQuery.Result` to present the result;