### PR TITLE
Loosen dependency requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,8 +42,8 @@ defmodule ReqBigQuery.MixProject do
   defp deps do
     [
       {:decimal, "~> 2.0"},
-      {:req, ">= 0.4.0"},
-      {:goth, ">= 1.3.0"},
+      {:req, "~> 0.3.5 or ~> 0.4"},
+      {:goth, "~> 1.3"},
       {:table, "~> 0.1.1", optional: true},
       {:ex_doc, ">= 0.0.0", only: :docs, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -42,8 +42,8 @@ defmodule ReqBigQuery.MixProject do
   defp deps do
     [
       {:decimal, "~> 2.0"},
-      {:req, "~> 0.3.5 or ~> 0.4.0"},
-      {:goth, "~> 1.3.0"},
+      {:req, ">= 0.4.0"},
+      {:goth, ">= 1.3.0"},
       {:table, "~> 0.1.1", optional: true},
       {:ex_doc, ">= 0.0.0", only: :docs, runtime: false}
     ]


### PR DESCRIPTION
Loosen dependency requirements so that req_bigquery is installable with newer versions of req and goth.